### PR TITLE
fix: added giving back ownership of root domain to DAO owner for full ENS path

### DIFF
--- a/contracts/ENSDaoRegistrar.sol
+++ b/contracts/ENSDaoRegistrar.sol
@@ -106,7 +106,7 @@ contract ENSDaoRegistrar is ERC1155Holder, Ownable {
    * @notice Give back the root domain of the ENS Dao Registrar.
    * @dev Can be called by the owner of the registrar.
    */
-  function giveBackRootToDaoOwner() public onlyOwner {
+  function giveBackDomainOwnership() public onlyOwner {
     if (address(_nameWrapper) != address(0)) {
       _nameWrapper.unwrapETH2LD(keccak256(bytes(_name)), owner(), owner());
     } else {

--- a/test/ens-dao.spec.ts
+++ b/test/ens-dao.spec.ts
@@ -415,9 +415,9 @@ describe('ENS', () => {
           ownerSigner.address
         );
         await expect(
-          ensDaoRegistrar.connect(userSigner).giveBackRootToDaoOwner()
+          ensDaoRegistrar.connect(userSigner).giveBackDomainOwnership()
         ).to.be.revertedWith('Ownable: caller is not the owner');
-        await ensDaoRegistrar.connect(ownerSigner).giveBackRootToDaoOwner();
+        await ensDaoRegistrar.connect(ownerSigner).giveBackDomainOwnership();
         expect(await registrar.balanceOf(ownerSigner.address)).to.be.equal(
           ethEnsBalanceBefore.add(1)
         );
@@ -489,10 +489,10 @@ describe('ENS', () => {
       });
       it('Sismo.eth initial owner should be able to get back ownership of the root domain', async () => {
         await expect(
-          ensDaoRegistrar.connect(userSigner).giveBackRootToDaoOwner()
+          ensDaoRegistrar.connect(userSigner).giveBackDomainOwnership()
         ).to.be.revertedWith('Ownable: caller is not the owner');
 
-        await ensDaoRegistrar.connect(ownerSigner).giveBackRootToDaoOwner();
+        await ensDaoRegistrar.connect(ownerSigner).giveBackDomainOwnership();
 
         expect(await ens.name(`${sismoLabel}.eth`).getOwner()).to.be.equal(
           ownerSigner.address


### PR DESCRIPTION
## Summary

RESOLVES #4 

- renamed `unwrapToDaoOwner` method to `giveBackDomainOwnership` and updated logic in order to handle no name wrapper,
- updated test