### PR TITLE
feat: added deployment name to deploy-ens-full allowing parallel tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:sdao-reserved-limited": "hardhat test ./test/subdomain-dao/sdao-reserved-limited.spec.ts",
     "test:ens-label-booker": "hardhat test ./test/ens-label-booker.spec.ts",
     "test:ens-registry": "hardhat test ./test/ens-registry.spec.ts",
-    "test": "npm run test:sdao-erc1155-generator && npm run test:sdao-erc721-generator && npm run test:sdao-code-accessible && npm run test:sdao-claimable && npm run test:sdao-registry && npm run test:sdao-reserved-limited  && npm run test:ens-label-booker && npm run test:ens-registry",
+    "test": "hardhat test ./test/*.spec.ts ./test/**/*.spec.ts",
     "format": "pretty-quick --pattern 'contracts/**/*.sol' --pattern 'libs/**/*.ts'  --pattern 'test/**/*.ts' --pattern 'tasks/**/*.ts' --pattern 'server/**/*.ts'"
   },
   "repository": {

--- a/tasks/deploy/deploy-ens-full.ts
+++ b/tasks/deploy/deploy-ens-full.ts
@@ -18,6 +18,8 @@ import { DeployedSDao } from './subdomain-dao/deploy-sdao';
 type DeployEnsFullArgs = {
   // additionally deploy SDAO contracts
   sDao?: boolean;
+  // Name of the deployment
+  deploymentName: string;
   // enabling logging
   log?: boolean;
 };
@@ -33,14 +35,15 @@ export type DeployedEns = {
 export type DeployedFullSuite = DeployedEns | (DeployedEns & DeployedSDao);
 
 async function deploiementAction(
-  { sDao, log }: DeployEnsFullArgs,
+  { sDao, deploymentName, log }: DeployEnsFullArgs,
   hre: HardhatRuntimeEnvironment
 ): Promise<DeployedFullSuite> {
   if (log) await logHre(hre);
 
   const deployer = await getDeployer(hre, log);
 
-  const newEnsDeployer = await hre.deployments.deploy('ENSDeployer', {
+  const newEnsDeployer = await hre.deployments.deploy(deploymentName, {
+    contract: 'ENSDeployer',
     from: deployer.address,
     args: [],
   });

--- a/test/ens-label-booker.spec.ts
+++ b/test/ens-label-booker.spec.ts
@@ -22,7 +22,9 @@ describe('ENS Label Booker', () => {
   let snapshotId: string;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_LABEL_BOOKER_TEST_SUITE',
+    });
     ({ registry } = deployedENS);
 
     const deployedLabelBooker: DeployedLabelBooker = await HRE.run(

--- a/test/ens-registry.spec.ts
+++ b/test/ens-registry.spec.ts
@@ -33,7 +33,9 @@ describe('ENS: Register domain, set owners, set lookup and reverse lookup, creat
   let ens: ENS;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_REGISTRY_TEST_SUITE',
+    });
     ({ registrar, registry, reverseRegistrar, publicResolver } = deployedENS);
 
     ens = await new ENS({

--- a/test/subdomain-dao/sdao-claimable.spec.ts
+++ b/test/subdomain-dao/sdao-claimable.spec.ts
@@ -41,7 +41,9 @@ describe('SDAO Registrar - Claimable', () => {
   let snapshotId: string;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_CLAIMABLE_EXTENSION_TEST_SUITE',
+    });
     ({ registry, reverseRegistrar, publicResolver, registrar } = deployedENS);
 
     const deployedSDao: DeployedSDaoPresetClaimable = await HRE.run(

--- a/test/subdomain-dao/sdao-code-accessible.spec.ts
+++ b/test/subdomain-dao/sdao-code-accessible.spec.ts
@@ -55,7 +55,9 @@ describe('SDAO Registrar - Limited Code Accessible', () => {
     groupId = await getWeeklyGroupId(HRE);
     chainId = Number(await HRE.getChainId());
 
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_LIMITED_EXTENSION_TEST_SUITE',
+    });
     ({ registry, reverseRegistrar, publicResolver, registrar } = deployedENS);
 
     const deployedSDao: DeployedSDaoPresetCodeAccessible = await HRE.run(

--- a/test/subdomain-dao/sdao-erc1155-generator.spec.ts
+++ b/test/subdomain-dao/sdao-erc1155-generator.spec.ts
@@ -43,7 +43,9 @@ describe('SDAO Registrar - ERC1155 Generator', () => {
   let snapshotId: string;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_ERC1155_EXTENSION_TEST_SUITE',
+    });
     ({ registry, reverseRegistrar, publicResolver, registrar } = deployedENS);
 
     const deployedSDao: DeployedSDaoPresetERC1155 = await HRE.run(

--- a/test/subdomain-dao/sdao-erc721-generator.spec.ts
+++ b/test/subdomain-dao/sdao-erc721-generator.spec.ts
@@ -43,7 +43,9 @@ describe('SDAO Registrar - ERC721 Generator', () => {
   let snapshotId: string;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_ERC721_EXTENSION_TEST_SUITE',
+    });
     ({ registry, reverseRegistrar, publicResolver, registrar } = deployedENS);
 
     const deployedSDao: DeployedSDaoPresetERC721 = await HRE.run(

--- a/test/subdomain-dao/sdao-registry.spec.ts
+++ b/test/subdomain-dao/sdao-registry.spec.ts
@@ -41,7 +41,9 @@ describe('SDAO Registrar', () => {
   let snapshotId: string;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_SDAO_REGISTRAR_TEST_SUITE',
+    });
     ({ registry, reverseRegistrar, publicResolver, registrar } = deployedENS);
 
     const deployedSDao: DeployedSDao = await HRE.run('deploy-sdao', {

--- a/test/subdomain-dao/sdao-reserved-limited.spec.ts
+++ b/test/subdomain-dao/sdao-reserved-limited.spec.ts
@@ -41,7 +41,9 @@ describe('SDAO Registrar - Reserved Limited', () => {
   let snapshotId: string;
 
   before(async () => {
-    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full');
+    const deployedENS: DeployedEns = await HRE.run('deploy-ens-full', {
+      deploymentName: 'ENS_RESERVED_LIMITED_EXTENSION_TEST_SUITE',
+    });
     ({ registry, reverseRegistrar, publicResolver, registrar } = deployedENS);
 
     const deployedSDao: DeployedSDaoPresetERC1155 = await HRE.run(


### PR DESCRIPTION
## Summary

- added `deploymentName` to `deploy-ens-full`,
- set the latter to different string for each test,
- run all tests in a run.

Resolves #30 